### PR TITLE
Fix numpy build error, add some dev dependencies (jq, nano)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@ FROM amazonlinux:2018.03
 # Need to set "ulimit -n" to a small value to stop yum from hanging:
 # https://bugzilla.redhat.com/show_bug.cgi?id=1715254#c1
 RUN ulimit -n 1024 && yum -y update && yum -y install \
-    git \
-    gcc \
-    python36 \
-    python36-pip \
-    python36-devel \
-	jq \
-	nano \
-	unzip \
-    zip \
-    && yum clean all
+  git \
+  gcc \
+  python36 \
+  python36-pip \
+  python36-devel \
+  jq \
+  nano \
+  unzip \
+  zip \
+  && yum clean all
 
 COPY requirements.txt quilt/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN ulimit -n 1024 && yum -y update && yum -y install \
     python36 \
     python36-pip \
     python36-devel \
+	jq \
+	nano \
+	unzip \
     zip \
     && yum clean all
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,16 @@ FROM amazonlinux:2018.03
 # Need to set "ulimit -n" to a small value to stop yum from hanging:
 # https://bugzilla.redhat.com/show_bug.cgi?id=1715254#c1
 RUN ulimit -n 1024 && yum -y update && yum -y install \
-  git \
-  gcc \
-  python36 \
-  python36-pip \
-  python36-devel \
-  jq \
-  nano \
-  unzip \
-  zip \
-  && yum clean all
+	git \
+	gcc \
+	python36 \
+	python36-pip \
+	python36-devel \
+	jq \
+	nano \
+	unzip \
+	zip \
+	&& yum clean all
 
 COPY requirements.txt quilt/requirements.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # from `pip freeze` under Python 3.6 lambda image 16-Apr-2020
 boto3==1.12.22
 botocore==1.15.22
-Cython==0.29.16 
+Cython==0.29.21
 docutils==0.15.2
 jmespath==0.9.5
 python-dateutil==2.8.1


### PR DESCRIPTION
Not clear how, in a pinned container with pinned requirements this suddenly started happening, but we must not be pinning numpy completely?

```
RuntimeError: Building NumPy requires Cython >= 0.29.21 
```